### PR TITLE
Fix TcpClientHandler Timeout

### DIFF
--- a/SharpServer/Sockets/TcpClientHandler.cs
+++ b/SharpServer/Sockets/TcpClientHandler.cs
@@ -31,6 +31,7 @@ namespace SharpServer.Sockets {
         /// <param name="server">TcpServerHandler this client connection belongs too.</param>
         public TcpClientHandler( SocketBinder binder, TcpServerHandler server, uint timeout ) : base( binder ) {
             Server = server;
+            Timeout = timeout;
             Receiver = null;
             Stream = null;
         }


### PR DESCRIPTION
Client.Timeout was not being set to the given timeout uint arg in the Constructor.
